### PR TITLE
fix: #6 - User Entity 및 DTO 확장 (구글, 네이버 지원)

### DIFF
--- a/src/auth/dto/social-login.dto.ts
+++ b/src/auth/dto/social-login.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsString } from 'class-validator';
+import { IsEmail, IsString, IsEnum, IsOptional } from 'class-validator';
 import { emailValidationMessage } from 'src/common/validation-message/email-validation.message';
 import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
 import { LoginType } from 'src/user/entities/user.entity';
@@ -10,9 +10,30 @@ export class SocialLoginDto {
   @IsString({ message: stringValidationMessage })
   nickname: string;
 
-  type: LoginType.KAKAO;
+  @IsEnum(LoginType)
+  type: LoginType;
 
-  kakaoAccessToken: string;
+  @IsOptional()
+  @IsString()
+  kakaoAccessToken?: string;
 
-  kakaoRefreshToken: string;
+  @IsOptional()
+  @IsString()
+  kakaoRefreshToken?: string;
+
+  @IsOptional()
+  @IsString()
+  googleAccessToken?: string;
+
+  @IsOptional()
+  @IsString()
+  googleRefreshToken?: string;
+
+  @IsOptional()
+  @IsString()
+  naverAccessToken?: string;
+
+  @IsOptional()
+  @IsString()
+  naverRefreshToken?: string;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -22,6 +22,8 @@ export enum Role {
 export enum LoginType {
   NORMAL = 'NORMAL',
   KAKAO = 'KAKAO',
+  GOOGLE = 'GOOGLE',
+  NAVER = 'NAVER',
 }
 
 export interface PushSubscriptions {


### PR DESCRIPTION
## Summary

이슈 #6를 해결하기 위해 User Entity와 SocialLoginDto를 확장했습니다.

### 변경 사항

- **LoginType enum 확장** (`src/user/entities/user.entity.ts:22`)
  - `GOOGLE` 타입 추가
  - `NAVER` 타입 추가

- **SocialLoginDto 확장** (`src/auth/dto/social-login.dto.ts`)
  - `type` 필드를 `LoginType.KAKAO`에서 `LoginType` enum으로 변경하여 모든 소셜 로그인 타입 지원
  - 구글 토큰 필드 추가: `googleAccessToken`, `googleRefreshToken`
  - 네이버 토큰 필드 추가: `naverAccessToken`, `naverRefreshToken`
  - 기존 카카오 토큰 필드를 optional로 변경: `kakaoAccessToken?`, `kakaoRefreshToken?`
  - `IsEnum`, `IsOptional` 데코레이터 추가하여 validation 강화

### 주요 개선점

- 타입별로 다른 토큰 필드를 저장할 수 있도록 구조 개선
- 모든 토큰 필드를 optional로 설정하여 소셜 로그인 타입에 따라 필요한 필드만 사용 가능
- 기존 카카오 구조를 유지하면서 확장하여 하위 호환성 유지

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Google 및 Naver를 통한 소셜 로그인 기능이 추가되었습니다. 사용자는 이제 기존 Kakao 로그인에 더하여 Google 및 Naver 계정을 사용하여 더욱 편리하게 로그인할 수 있습니다. 여러 소셜 플랫폼을 지원함으로써 다양한 사용자의 접근성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->